### PR TITLE
feat: Add advanced filters to Scryfall search modal

### DIFF
--- a/src/components/ScryfallSearchModal.tsx
+++ b/src/components/ScryfallSearchModal.tsx
@@ -9,6 +9,7 @@ import { Button } from "./ui/button";
 import { Label } from "./ui/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "./ui/select";
 import { Checkbox } from "./ui/checkbox";
+import { Input } from "./ui/input";
 
 interface ScryfallSearchModalProps {
   options: ScryfallSearchOptions;
@@ -19,14 +20,35 @@ interface ScryfallSearchModalProps {
 export default function ScryfallSearchModal({ options, onSave, onClose }: ScryfallSearchModalProps) {
   const { t } = useLanguage();
   const [currentOptions, setCurrentOptions] = useState<ScryfallSearchOptions>(options);
+  const [newLegalityFormat, setNewLegalityFormat] = useState('');
 
   const handleSave = () => {
     onSave(currentOptions);
   };
 
+  const addLegality = () => {
+    if (newLegalityFormat && currentOptions.legalities && !currentOptions.legalities[newLegalityFormat]) {
+      setCurrentOptions(prev => ({
+        ...prev,
+        legalities: {
+          ...prev.legalities,
+          [newLegalityFormat]: 'legal'
+        }
+      }));
+      setNewLegalityFormat('');
+    }
+  };
+
+  const removeLegality = (format: string) => {
+    const newLegalities = {...currentOptions.legalities};
+    delete newLegalities[format];
+    setCurrentOptions(prev => ({...prev, legalities: newLegalities}));
+  };
+
   const uniqueOptions = ['cards', 'art', 'prints'];
   const orderOptions = ['name', 'set', 'released', 'rarity', 'color', 'usd', 'tix', 'eur', 'cmc', 'power', 'toughness', 'edhrec', 'artist'];
   const dirOptions = ['auto', 'asc', 'desc'];
+  const rarityOptions = ['common', 'uncommon', 'rare', 'mythic'];
 
   return (
     <Dialog open={true} onOpenChange={onClose}>
@@ -85,6 +107,69 @@ export default function ScryfallSearchModal({ options, onSave, onClose }: Scryfa
                 ))}
               </SelectContent>
             </Select>
+          </div>
+
+          <div className="grid grid-cols-4 items-center gap-4">
+            <Label htmlFor="type_line" className="text-right">{t('scryfallModal.type_line')}</Label>
+            <Input id="type_line" value={currentOptions.type_line || ''} onChange={(e) => setCurrentOptions(prev => ({...prev, type_line: e.target.value}))} className="col-span-3" />
+          </div>
+
+          <div className="grid grid-cols-4 items-center gap-4">
+            <Label htmlFor="artist" className="text-right">{t('scryfallModal.artist')}</Label>
+            <Input id="artist" value={currentOptions.artist || ''} onChange={(e) => setCurrentOptions(prev => ({...prev, artist: e.target.value}))} className="col-span-3" />
+          </div>
+
+          <div className="grid grid-cols-4 items-center gap-4">
+            <Label htmlFor="rarity" className="text-right">{t('scryfallModal.rarity')}</Label>
+            <Select
+              value={currentOptions.rarity}
+              onValueChange={(value) => setCurrentOptions(prev => ({...prev, rarity: value as ScryfallSearchOptions['rarity']}))}
+            >
+              <SelectTrigger id="rarity" className="col-span-3">
+                <SelectValue placeholder="Select..." />
+              </SelectTrigger>
+              <SelectContent>
+                {rarityOptions.map(opt => (
+                  <SelectItem key={opt} value={opt}>{t(`scryfallModal.rarityOptions.${opt}` as any)}</SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="flex items-center space-x-2 justify-center">
+            <Checkbox id="is_token" checked={currentOptions.is_token} onCheckedChange={(checked) => setCurrentOptions(prev => ({...prev, is_token: !!checked}))} />
+            <Label htmlFor="is_token">{t('scryfallModal.is_token')}</Label>
+          </div>
+
+          <div className="flex items-center space-x-2 justify-center">
+            <Checkbox id="foil" checked={currentOptions.foil} onCheckedChange={(checked) => setCurrentOptions(prev => ({...prev, foil: !!checked}))} />
+            <Label htmlFor="foil">{t('scryfallModal.foil')}</Label>
+          </div>
+
+          <div>
+            <Label>{t('scryfallModal.legalities')}</Label>
+            {currentOptions.legalities && Object.entries(currentOptions.legalities).map(([format, legality]) => (
+              <div key={format} className="grid grid-cols-3 items-center gap-2 mt-2">
+                <Input value={format} readOnly className="col-span-1" />
+                <Select
+                  value={legality}
+                  onValueChange={(value) => setCurrentOptions(prev => ({...prev, legalities: {...prev.legalities, [format]: value as 'legal' | 'not_legal'}}))}
+                >
+                  <SelectTrigger className="col-span-1">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="legal">{t('scryfallModal.legal')}</SelectItem>
+                    <SelectItem value="not_legal">{t('scryfallModal.not_legal')}</SelectItem>
+                  </SelectContent>
+                </Select>
+                <Button type="button" variant="destructive" onClick={() => removeLegality(format)}>{t('scryfallModal.remove')}</Button>
+              </div>
+            ))}
+            <div className="grid grid-cols-3 items-center gap-2 mt-2">
+              <Input placeholder={t('scryfallModal.format')} value={newLegalityFormat} onChange={(e) => setNewLegalityFormat(e.target.value)} className="col-span-2" />
+              <Button type="button" onClick={addLegality}>{t('scryfallModal.add')}</Button>
+            </div>
           </div>
 
           <div className="flex items-center space-x-2 justify-center">

--- a/src/hooks/useCardSearch.ts
+++ b/src/hooks/useCardSearch.ts
@@ -34,9 +34,21 @@ const normalizePokemonTcgData = (card: any): NormalizedCard => {
 
 const searchScryfall = async (query: string, options?: ScryfallSearchOptions): Promise<NormalizedCard[] | null> => {
   const params = new URLSearchParams();
-  params.append('q', query);
+  let fullQuery = query;
 
   if (options) {
+    if (options.type_line) fullQuery += ` t:"${options.type_line}"`;
+    if (options.is_token) fullQuery += ` is:token`;
+    if (options.legalities) {
+      for (const [format, legality] of Object.entries(options.legalities)) {
+        if (legality === 'legal') fullQuery += ` f:${format}`;
+        else fullQuery += ` -f:${format}`;
+      }
+    }
+    if (options.foil) fullQuery += ` is:foil`;
+    if (options.rarity) fullQuery += ` r:${options.rarity}`;
+    if (options.artist) fullQuery += ` a:"${options.artist}"`;
+
     if (options.unique) params.append('unique', options.unique);
     if (options.order) params.append('order', options.order);
     if (options.dir) params.append('dir', options.dir);
@@ -48,6 +60,8 @@ const searchScryfall = async (query: string, options?: ScryfallSearchOptions): P
     params.append('unique', 'prints');
     params.append('include_extras', 'true');
   }
+
+  params.append('q', fullQuery);
 
   const response = await fetch(`https://api.scryfall.com/cards/search?${params.toString()}`);
 

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -48,6 +48,17 @@ export const en = {
     include_variations: 'Include rare variants',
     save: 'Save',
     cancel: 'Cancel',
+    type_line: 'Type Line',
+    artist: 'Artist',
+    rarity: 'Rarity',
+    is_token: 'Is Token',
+    foil: 'Is Foil',
+    legalities: 'Legalities',
+    legal: 'Legal',
+    not_legal: 'Not Legal',
+    remove: 'Remove',
+    add: 'Add',
+    format: 'Format',
     uniqueOptions: {
       cards: 'Cards',
       art: 'Art',
@@ -72,6 +83,12 @@ export const en = {
       auto: 'Auto',
       asc: 'Ascending',
       desc: 'Descending',
+    },
+    rarityOptions: {
+      common: 'Common',
+      uncommon: 'Uncommon',
+      rare: 'Rare',
+      mythic: 'Mythic Rare',
     }
   },
   pokemonTcgModal: {

--- a/src/lib/i18n/it.ts
+++ b/src/lib/i18n/it.ts
@@ -48,6 +48,17 @@ export const it = {
     include_variations: 'Includi varianti rare',
     save: 'Salva',
     cancel: 'Annulla',
+    type_line: 'Riga Tipo',
+    artist: 'Artista',
+    rarity: 'Rarità',
+    is_token: 'È Token',
+    foil: 'È Foil',
+    legalities: 'Legalità',
+    legal: 'Legale',
+    not_legal: 'Non Legale',
+    remove: 'Rimuovi',
+    add: 'Aggiungi',
+    format: 'Formato',
     uniqueOptions: {
       cards: 'Carte',
       art: 'Arte',
@@ -72,6 +83,12 @@ export const it = {
       auto: 'Auto',
       asc: 'Ascendente',
       desc: 'Discendente',
+    },
+    rarityOptions: {
+      common: 'Comune',
+      uncommon: 'Non Comune',
+      rare: 'Rara',
+      mythic: 'Mitica',
     }
   },
   pokemonTcgModal: {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -11,6 +11,12 @@ export interface ScryfallSearchOptions {
   include_extras?: boolean;
   include_multilingual?: boolean;
   include_variations?: boolean;
+  type_line?: string;
+  is_token?: boolean;
+  legalities?: { [key: string]: 'legal' | 'not_legal' };
+  foil?: boolean;
+  rarity?: 'common' | 'uncommon' | 'rare' | 'mythic';
+  artist?: string;
 }
 
 export interface PokemonTcgSearchOptions {


### PR DESCRIPTION
This commit introduces advanced filtering capabilities to the Scryfall search modal, allowing users to refine their card searches based on several criteria.

The following filters have been added:
- Type Line: Filter by the card's type line (e.g., "Creature — Goblin").
- Token: Filter for token cards.
- Legalities: Filter by format legalities (e.g., legal in Modern, not legal in Standard).
- Foil: Filter for foil versions of cards.
- Rarity: Filter by card rarity (Common, Uncommon, Rare, Mythic).
- Artist: Filter by the card's artist.

To support these changes, the following modifications were made:
- The `ScryfallSearchOptions` type in `src/lib/types.ts` was extended to include the new filter properties.
- The `useCardSearch` hook in `src/hooks/useCardSearch.ts` was updated to construct the Scryfall API query with the new filters.
- The `ScryfallSearchModal` component in `src/components/ScryfallSearchModal.tsx` was updated with UI controls for the new filters.
- English and Italian translations for the new UI elements were added to `src/lib/i18n/en.ts` and `src/lib/i18n/it.ts`.