### PR TITLE
Fix header layout mismatch on homepage

### DIFF
--- a/src/components/CardTable.tsx
+++ b/src/components/CardTable.tsx
@@ -14,6 +14,7 @@ export default function CardTable({ rows }: CardTableProps) {
     <Table>
       <TableHeader>
         <TableRow>
+          <TableHead className="w-12"></TableHead>
           <TableHead className="w-[100px]">{t('table.image')}</TableHead>
           <TableHead>{t('table.cardName')}</TableHead>
           <TableHead className="w-[150px]">{t('table.quantity')}</TableHead>


### PR DESCRIPTION
Fixed misalignment between header and content rows in the main page table. The CardRow component had 6 columns (including a checkbox column at the start), but the CardTable header only had 5 columns, causing the layout to break. Added an empty TableHead with w-12 width to match the checkbox column.