### PR TITLE
🧹 Improve type safety in i18n and card providers

### DIFF
--- a/npm_output.log
+++ b/npm_output.log
@@ -1,9 +1,0 @@
-
-> nextn@0.1.0 dev
-> next dev --turbopack -p 9002
-
-   ▲ Next.js 15.3.3 (Turbopack)
-   - Local:        http://localhost:9002
-   - Network:      http://192.168.0.2:9002
-
- ✓ Starting...

--- a/src/api/providers.ts
+++ b/src/api/providers.ts
@@ -1,6 +1,6 @@
-import type { Provider } from "@/lib/types";
+import type { Provider, ProviderId } from "@/lib/types";
 
-export const availableProviders: Omit<Provider, 'name'>[] = [
+export const availableProviders: Pick<Provider, 'id'>[] = [
   { id: 'scryfall' },
   { id: 'pokemontcg' },
 ];

--- a/src/components/CardItem.tsx
+++ b/src/components/CardItem.tsx
@@ -201,7 +201,7 @@ export default function CardItem({ row }: CardItemProps) {
                 </SelectTrigger>
                 <SelectContent>
                     {availableProviders.map(p => (
-                    <SelectItem key={p.id} value={p.id}>{t(`providers.${p.id}` as any)}</SelectItem>
+                    <SelectItem key={p.id} value={p.id}>{t(`providers.${p.id}`)}</SelectItem>
                     ))}
                 </SelectContent>
               </Select>

--- a/src/components/CardRow.tsx
+++ b/src/components/CardRow.tsx
@@ -220,7 +220,7 @@ export default function CardRowComponent({ row }: CardRowProps) {
             </SelectTrigger>
             <SelectContent>
               {availableProviders.map(p => (
-                <SelectItem key={p.id} value={p.id}>{t(`providers.${p.id}` as any)}</SelectItem>
+                <SelectItem key={p.id} value={p.id}>{t(`providers.${p.id}`)}</SelectItem>
               ))}
             </SelectContent>
           </Select>

--- a/src/components/PokemonTcgSearchModal.tsx
+++ b/src/components/PokemonTcgSearchModal.tsx
@@ -24,8 +24,8 @@ export default function PokemonTcgSearchModal({ options, onSave, onClose }: Poke
     onSave(currentOptions);
   };
 
-  const orderOptions = ['name', 'set.releaseDate', 'set.name', 'number', 'artist', 'rarity', 'nationalPokedexNumbers'];
-  const dirOptions = ['asc', 'desc'];
+  const orderOptions = ['name', 'set.releaseDate', 'set.name', 'number', 'artist', 'rarity', 'nationalPokedexNumbers'] as const;
+  const dirOptions = ['asc', 'desc'] as const;
 
   return (
     <Dialog open={true} onOpenChange={onClose}>
@@ -54,7 +54,7 @@ export default function PokemonTcgSearchModal({ options, onSave, onClose }: Poke
               </SelectTrigger>
               <SelectContent>
                 {orderOptions.map(opt => (
-                  <SelectItem key={opt} value={opt}>{t(`pokemonTcgModal.orderOptions.${opt}` as any)}</SelectItem>
+                  <SelectItem key={opt} value={opt}>{t(`pokemonTcgModal.orderOptions.${opt}`)}</SelectItem>
                 ))}
               </SelectContent>
             </Select>
@@ -71,7 +71,7 @@ export default function PokemonTcgSearchModal({ options, onSave, onClose }: Poke
               </SelectTrigger>
               <SelectContent>
                 {dirOptions.map(opt => (
-                  <SelectItem key={opt} value={opt}>{t(`pokemonTcgModal.dirOptions.${opt}` as any)}</SelectItem>
+                  <SelectItem key={opt} value={opt}>{t(`pokemonTcgModal.dirOptions.${opt}`)}</SelectItem>
                 ))}
               </SelectContent>
             </Select>

--- a/src/components/ScryfallSearchModal.tsx
+++ b/src/components/ScryfallSearchModal.tsx
@@ -45,10 +45,10 @@ export default function ScryfallSearchModal({ options, onSave, onClose }: Scryfa
     setCurrentOptions(prev => ({...prev, legalities: newLegalities}));
   };
 
-  const uniqueOptions = ['cards', 'art', 'prints'];
-  const orderOptions = ['name', 'set', 'released', 'rarity', 'color', 'usd', 'tix', 'eur', 'cmc', 'power', 'toughness', 'edhrec', 'artist'];
-  const dirOptions = ['auto', 'asc', 'desc'];
-  const rarityOptions = ['common', 'uncommon', 'rare', 'mythic'];
+  const uniqueOptions = ['cards', 'art', 'prints'] as const;
+  const orderOptions = ['name', 'set', 'released', 'rarity', 'color', 'usd', 'tix', 'eur', 'cmc', 'power', 'toughness', 'edhrec', 'artist'] as const;
+  const dirOptions = ['auto', 'asc', 'desc'] as const;
+  const rarityOptions = ['common', 'uncommon', 'rare', 'mythic'] as const;
 
   return (
     <Dialog open={true} onOpenChange={onClose}>
@@ -69,7 +69,7 @@ export default function ScryfallSearchModal({ options, onSave, onClose }: Scryfa
               </SelectTrigger>
               <SelectContent>
                 {uniqueOptions.map(opt => (
-                  <SelectItem key={opt} value={opt}>{t(`scryfallModal.uniqueOptions.${opt}` as any)}</SelectItem>
+                  <SelectItem key={opt} value={opt}>{t(`scryfallModal.uniqueOptions.${opt}`)}</SelectItem>
                 ))}
               </SelectContent>
             </Select>
@@ -86,7 +86,7 @@ export default function ScryfallSearchModal({ options, onSave, onClose }: Scryfa
               </SelectTrigger>
               <SelectContent>
                 {orderOptions.map(opt => (
-                  <SelectItem key={opt} value={opt}>{t(`scryfallModal.orderOptions.${opt}` as any)}</SelectItem>
+                  <SelectItem key={opt} value={opt}>{t(`scryfallModal.orderOptions.${opt}`)}</SelectItem>
                 ))}
               </SelectContent>
             </Select>
@@ -103,7 +103,7 @@ export default function ScryfallSearchModal({ options, onSave, onClose }: Scryfa
               </SelectTrigger>
               <SelectContent>
                 {dirOptions.map(opt => (
-                  <SelectItem key={opt} value={opt}>{t(`scryfallModal.dirOptions.${opt}` as any)}</SelectItem>
+                  <SelectItem key={opt} value={opt}>{t(`scryfallModal.dirOptions.${opt}`)}</SelectItem>
                 ))}
               </SelectContent>
             </Select>
@@ -130,7 +130,7 @@ export default function ScryfallSearchModal({ options, onSave, onClose }: Scryfa
               </SelectTrigger>
               <SelectContent>
                 {rarityOptions.map(opt => (
-                  <SelectItem key={opt} value={opt}>{t(`scryfallModal.rarityOptions.${opt}` as any)}</SelectItem>
+                  <SelectItem key={opt} value={opt}>{t(`scryfallModal.rarityOptions.${opt}`)}</SelectItem>
                 ))}
               </SelectContent>
             </Select>

--- a/src/context/LanguageContext.tsx
+++ b/src/context/LanguageContext.tsx
@@ -9,15 +9,25 @@ type Language = 'en' | 'it';
 
 const translations = { en, it };
 
+export type Paths<T> = T extends string
+  ? never
+  : {
+      [K in keyof T & string]: T[K] extends string
+        ? K
+        : K | `${K}.${Paths<T[K]>}`;
+    }[keyof T & string];
+
+export type TranslationKey = Paths<typeof en>;
+
 // Function to perform translations with placeholders
-const translate = (lang: Language, key: string, placeholders: { [key: string]: string } = {}): string => {
-    const keys = key.split('.');
+const translate = (lang: Language, key: TranslationKey, placeholders: { [key: string]: string } = {}): string => {
+    const keys = (key as string).split('.');
     let a: any = translations[lang];
     for (const k of keys) {
         if (a && typeof a === 'object' && k in a) {
             a = a[k];
         } else {
-            return key; // Return key if not found
+            return key as string; // Return key if not found
         }
     }
     
@@ -34,7 +44,7 @@ const translate = (lang: Language, key: string, placeholders: { [key: string]: s
 interface LanguageContextType {
   language: Language;
   setLanguage: (language: Language) => void;
-  t: (key: string, placeholders?: { [key: string]: string }) => string;
+  t: (key: TranslationKey, placeholders?: { [key: string]: string }) => string;
 }
 
 const LanguageContext = createContext<LanguageContextType | undefined>(undefined);
@@ -42,7 +52,7 @@ const LanguageContext = createContext<LanguageContextType | undefined>(undefined
 export const LanguageProvider = ({ children }: { children: ReactNode }) => {
   const [language, setLanguage] = useState<Language>('en');
 
-  const t = (key: string, placeholders?: { [key: string]: string }) => {
+  const t = (key: TranslationKey, placeholders?: { [key: string]: string }) => {
     return translate(language, key, placeholders);
   }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,6 +1,8 @@
 
+export type ProviderId = 'scryfall' | 'pokemontcg';
+
 export interface Provider {
-  id: string;
+  id: ProviderId;
   name: string;
 }
 
@@ -41,7 +43,7 @@ export interface CardRow {
   id: string;
   query: string;
   quantity: number;
-  providerId: string;
+  providerId: ProviderId;
   card: NormalizedCard | null;
   searchResults?: NormalizedCard[] | null;
   scryfallSearchOptions?: ScryfallSearchOptions;


### PR DESCRIPTION
This change improves the maintainability and readability of the codebase by eliminating unsafe `as any` type assertions when using the translation function `t()`. 

Key improvements:
1. **Strict Translation Keys**: Added a `TranslationKey` type that is automatically derived from the English translation file, ensuring that only valid translation keys can be passed to the `t()` function.
2. **Provider Typing**: Strictly typed provider IDs as a union of `'scryfall' | 'pokemontcg'`, which allows for type-safe dynamic translation key construction like `t(\`providers.\${p.id}\`)`.
3. **Consistent Refactoring**: Applied these improvements across all modals and components that were using the previous unsafe pattern.
4. **Verified Accuracy**: Manual verification was performed to ensure that all dynamic keys correctly match the keys in the i18n files.

---
*PR created automatically by Jules for task [5765503421629816805](https://jules.google.com/task/5765503421629816805) started by @giulioleuci*