### PR TITLE
⚡ Limit concurrent API requests in AppHeader to prevent N+1 issue

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -4,3 +4,22 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+export function limitConcurrency<T, R>(
+  items: T[],
+  limit: number,
+  fn: (item: T) => Promise<R>
+): Promise<R[]> {
+  const results: R[] = new Array(items.length);
+  const itemQueue = items.map((item, index) => ({ item, index }));
+
+  const worker = async () => {
+    while (itemQueue.length > 0) {
+      const { item, index } = itemQueue.shift()!;
+      results[index] = await fn(item);
+    }
+  };
+
+  const workers = Array.from({ length: Math.min(limit, items.length) }, () => worker());
+  return Promise.all(workers).then(() => results);
+}


### PR DESCRIPTION
💡 **What:** Replaced the unbounded parallel execution of search requests in `handleSearchAll` with a controlled concurrency limit of 5. Introduced a reusable `limitConcurrency` utility function in `src/lib/utils.ts`.

🎯 **Why:** Searching for a large number of cards (e.g., importing a decklist) would previously fire all API requests simultaneously. This could lead to:
*   Browser performance degradation.
*   Network congestion.
*   Hitting API rate limits (even with retries, a burst of requests is problematic).

📊 **Measured Improvement:**
*   **Baseline:** A reproduction script demonstrated that 50 requests were fired simultaneously (`maxActiveRequests: 50`).
*   **Improvement:** The same script using `limitConcurrency` with a limit of 5 showed exactly 5 simultaneous requests (`maxActiveRequests: 5`).
*   **User Impact:** Smoother UI during bulk searches and more reliable API interactions.

---
*PR created automatically by Jules for task [1868144520492446773](https://jules.google.com/task/1868144520492446773) started by @giulioleuci*