### PR TITLE
Fix type error in CardRow and CardItem provider select

### DIFF
--- a/src/components/CardItem.tsx
+++ b/src/components/CardItem.tsx
@@ -5,7 +5,7 @@ import { useSearch } from "@/context/SearchContext";
 import { useCardSearch } from "@/hooks/useCardSearch";
 import { useMultiSelect } from "@/context/MultiSelectContext";
 import { useDebounce } from "@/hooks/useDebounce";
-import type { CardRow, NormalizedCard, ScryfallSearchOptions, PokemonTcgSearchOptions } from "@/lib/types";
+import type { CardRow, NormalizedCard, ScryfallSearchOptions, PokemonTcgSearchOptions, ProviderId } from "@/lib/types";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
@@ -194,7 +194,7 @@ export default function CardItem({ row }: CardItemProps) {
             <div className="flex items-center gap-1">
               <Select
                 value={row.providerId}
-                onValueChange={(value) => handleUpdate({ providerId: value })}
+                onValueChange={(value) => handleUpdate({ providerId: value as ProviderId })}
               >
                 <SelectTrigger>
                     <SelectValue placeholder={t('card.selectProvider')} />

--- a/src/components/CardRow.tsx
+++ b/src/components/CardRow.tsx
@@ -6,7 +6,7 @@ import { useSearch } from "@/context/SearchContext";
 import { useCardSearch } from "@/hooks/useCardSearch";
 import { useMultiSelect } from "@/context/MultiSelectContext";
 import { useDebounce } from "@/hooks/useDebounce";
-import type { CardRow, NormalizedCard, ScryfallSearchOptions, PokemonTcgSearchOptions } from "@/lib/types";
+import type { CardRow, NormalizedCard, ScryfallSearchOptions, PokemonTcgSearchOptions, ProviderId } from "@/lib/types";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
@@ -213,7 +213,7 @@ export default function CardRowComponent({ row }: CardRowProps) {
         <div className="flex items-center gap-1">
           <Select
             value={row.providerId}
-            onValueChange={(value) => handleUpdate({ providerId: value })}
+            onValueChange={(value) => handleUpdate({ providerId: value as ProviderId })}
           >
             <SelectTrigger>
               <SelectValue placeholder={t('card.selectProvider')} />


### PR DESCRIPTION
Fixed TS2322 errors in CardRow.tsx and CardItem.tsx by casting value to ProviderId in Select's onValueChange. Also confirmed that the reported 'as any' usage in t() was already resolved.

---
*PR created automatically by Jules for task [16736546798336239929](https://jules.google.com/task/16736546798336239929) started by @giulioleuci*