### PR TITLE
Add Content Security Policy (CSP) to Root Layout

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -19,9 +19,25 @@ export default function RootLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const csp = `
+    default-src 'self';
+    script-src 'self' 'unsafe-inline' 'unsafe-eval';
+    style-src 'self' 'unsafe-inline' https://fonts.googleapis.com;
+    font-src 'self' https://fonts.gstatic.com;
+    img-src 'self' blob: data: https://cards.scryfall.io https://placehold.co https://picsum.photos https://images.pokemontcg.io;
+    connect-src 'self' https://api.scryfall.com https://api.pokemontcg.io https://cards.scryfall.io https://images.pokemontcg.io https://placehold.co https://picsum.photos;
+    frame-src 'none';
+    object-src 'none';
+    base-uri 'self';
+    upgrade-insecure-requests;
+  `
+    .replace(/\s{2,}/g, ' ')
+    .trim();
+
   return (
     <html lang="en" className="dark" suppressHydrationWarning>
       <head>
+        <meta httpEquiv="Content-Security-Policy" content={csp} />
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
         <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />


### PR DESCRIPTION
Implemented a Content Security Policy (CSP) in the root layout to secure the application against Cross-Site Scripting (XSS) and data injection attacks.
The policy allows necessary resources for the application to function, including:
- Google Fonts
- Scryfall API and images
- Pokemon TCG API and images
- Placeholder image services
- Internal scripts and styles (unsafe-inline/eval allowed for Next.js compatibility)

---
*PR created automatically by Jules for task [8653576378611146951](https://jules.google.com/task/8653576378611146951) started by @giulioleuci*